### PR TITLE
BE1 Sprint 3: Dashboard stats, self-registration fix, seed users, and tests

### DIFF
--- a/backend/handlers/auth_handler.go
+++ b/backend/handlers/auth_handler.go
@@ -28,7 +28,9 @@ type RegisterRequest struct {
 	Name     string `json:"name"`
 	Email    string `json:"email"`
 	Password string `json:"password"`
-	Role     string `json:"role"` // admin, hiring_manager, interviewer, candidate
+	// Role is intentionally ignored - self-registration always creates candidate role
+	// Admins use POST /users to create other roles
+	Role string `json:"role,omitempty"`
 }
 
 // LoginRequest represents the login request body
@@ -128,19 +130,9 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set default role if not provided
-	if req.Role == "" {
-		req.Role = "candidate"
-	}
-
-	// Validate role
-	validRoles := map[string]bool{"admin": true, "hiring_manager": true, "interviewer": true, "candidate": true}
-	if !validRoles[req.Role] {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid role"})
-		return
-	}
+	// Self-registration always creates candidate role
+	// Only admins can create other roles via POST /users
+	req.Role = "candidate"
 
 	// Create new user
 	user := models.User{

--- a/backend/handlers/auth_handler_test.go
+++ b/backend/handlers/auth_handler_test.go
@@ -1,433 +1,510 @@
 package handlers
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"testing"
+    "bytes"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
 
-	"backend/models"
+    "backend/models"
 
-	"github.com/glebarez/sqlite"
-	"gorm.io/gorm"
+    "github.com/glebarez/sqlite"
+    "gorm.io/gorm"
 )
 
 // setupTestDB creates an in-memory SQLite database for testing
 // Each test gets a fresh database - no real DB affected
 func setupTestDB(t *testing.T) *gorm.DB {
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
-	if err != nil {
-		t.Fatalf("Failed to open test database: %v", err)
-	}
-	if err := db.AutoMigrate(&models.User{}, &models.PasswordResetToken{}); err != nil {
-		t.Fatalf("Failed to migrate test database: %v", err)
-	}
-	return db
+    db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+    if err != nil {
+        t.Fatalf("Failed to open test database: %v", err)
+    }
+    if err := db.AutoMigrate(&models.User{}, &models.PasswordResetToken{}); err != nil {
+        t.Fatalf("Failed to migrate test database: %v", err)
+    }
+    return db
 }
 
 // makeRequest is a helper to create HTTP requests with JSON body
 func makeRequest(t *testing.T, method, url string, body interface{}) *http.Request {
-	jsonBody, err := json.Marshal(body)
-	if err != nil {
-		t.Fatalf("Failed to marshal request body: %v", err)
-	}
-	req, err := http.NewRequest(method, url, bytes.NewBuffer(jsonBody))
-	if err != nil {
-		t.Fatalf("Failed to create request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return req
+    jsonBody, err := json.Marshal(body)
+    if err != nil {
+        t.Fatalf("Failed to marshal request body: %v", err)
+    }
+    req, err := http.NewRequest(method, url, bytes.NewBuffer(jsonBody))
+    if err != nil {
+        t.Fatalf("Failed to create request: %v", err)
+    }
+    req.Header.Set("Content-Type", "application/json")
+    return req
 }
 
 // ─── Register Tests ───────────────────────────────────────────────────────────
 
 // TestRegister_Success verifies a valid user can register successfully
 func TestRegister_Success(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	body := map[string]string{
-		"name":     "John Doe",
-		"email":    "john@example.com",
-		"password": "SecurePass123!",
-		"role":     "hiring_manager",
-	}
+    body := map[string]string{
+        "name":     "John Doe",
+        "email":    "john@example.com",
+        "password": "SecurePass123!",
+        "role":     "hiring_manager", // Should be ignored - will become candidate
+    }
 
-	req := makeRequest(t, http.MethodPost, "/auth/register", body)
-	rr := httptest.NewRecorder()
-	handler.Register(rr, req)
+    req := makeRequest(t, http.MethodPost, "/auth/register", body)
+    rr := httptest.NewRecorder()
+    handler.Register(rr, req)
 
-	if rr.Code != http.StatusCreated {
-		t.Errorf("Expected status 201, got %d. Body: %s", rr.Code, rr.Body.String())
-	}
+    if rr.Code != http.StatusCreated {
+        t.Errorf("Expected status 201, got %d. Body: %s", rr.Code, rr.Body.String())
+    }
 
-	var response AuthResponse
-	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-	if response.User.Email != "john@example.com" {
-		t.Errorf("Expected email john@example.com, got %s", response.User.Email)
-	}
-	if response.AccessToken == "" {
-		t.Error("Expected access token in response, got empty string")
-	}
+    var response AuthResponse
+    if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+        t.Fatalf("Failed to decode response: %v", err)
+    }
+    if response.User.Email != "john@example.com" {
+        t.Errorf("Expected email john@example.com, got %s", response.User.Email)
+    }
+    if response.AccessToken == "" {
+        t.Error("Expected access token in response, got empty string")
+    }
+}
+
+// TestRegister_AlwaysCreatesCandidateRole verifies self-registration always creates candidate
+// regardless of what role is passed in the request body
+func TestRegister_AlwaysCreatesCandidateRole(t *testing.T) {
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
+
+    // Try to register as admin - should be forced to candidate
+    body := map[string]string{
+        "name":     "Sneaky User",
+        "email":    "sneaky@example.com",
+        "password": "SecurePass123!",
+        "role":     "admin", // Attempt privilege escalation
+    }
+
+    req := makeRequest(t, http.MethodPost, "/auth/register", body)
+    rr := httptest.NewRecorder()
+    handler.Register(rr, req)
+
+    if rr.Code != http.StatusCreated {
+        t.Errorf("Expected status 201, got %d", rr.Code)
+    }
+
+    // Verify role was forced to candidate in the database
+    var user models.User
+    db.Where("email = ?", "sneaky@example.com").First(&user)
+    if user.Role != "candidate" {
+        t.Errorf("Expected role 'candidate', got '%s' - privilege escalation not prevented!", user.Role)
+    }
+}
+
+// TestRegister_CannotRegisterAsHiringManager verifies hiring_manager role is rejected on self-register
+func TestRegister_CannotRegisterAsHiringManager(t *testing.T) {
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
+
+    body := map[string]string{
+        "name":     "Manager Wannabe",
+        "email":    "manager@example.com",
+        "password": "SecurePass123!",
+        "role":     "hiring_manager",
+    }
+
+    req := makeRequest(t, http.MethodPost, "/auth/register", body)
+    rr := httptest.NewRecorder()
+    handler.Register(rr, req)
+
+    // Should succeed but with candidate role
+    if rr.Code != http.StatusCreated {
+        t.Errorf("Expected status 201, got %d", rr.Code)
+    }
+
+    var user models.User
+    db.Where("email = ?", "manager@example.com").First(&user)
+    if user.Role != "candidate" {
+        t.Errorf("Expected role 'candidate', got '%s'", user.Role)
+    }
+}
+
+// TestRegister_NoRoleDefaultsToCandidate verifies omitting role still creates candidate
+func TestRegister_NoRoleDefaultsToCandidate(t *testing.T) {
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
+
+    body := map[string]string{
+        "name":     "John Doe",
+        "email":    "john@example.com",
+        "password": "SecurePass123!",
+        // No role provided
+    }
+
+    req := makeRequest(t, http.MethodPost, "/auth/register", body)
+    rr := httptest.NewRecorder()
+    handler.Register(rr, req)
+
+    if rr.Code != http.StatusCreated {
+        t.Errorf("Expected status 201, got %d", rr.Code)
+    }
+
+    var user models.User
+    db.Where("email = ?", "john@example.com").First(&user)
+    if user.Role != "candidate" {
+        t.Errorf("Expected default role 'candidate', got '%s'", user.Role)
+    }
 }
 
 // TestRegister_DuplicateEmail verifies duplicate email registration is rejected
 func TestRegister_DuplicateEmail(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	body := map[string]string{
-		"name":     "John Doe",
-		"email":    "john@example.com",
-		"password": "SecurePass123!",
-		"role":     "hiring_manager",
-	}
+    body := map[string]string{
+        "name":     "John Doe",
+        "email":    "john@example.com",
+        "password": "SecurePass123!",
+    }
 
-	// Register first time
-	req1 := makeRequest(t, http.MethodPost, "/auth/register", body)
-	rr1 := httptest.NewRecorder()
-	handler.Register(rr1, req1)
+    // Register first time
+    req1 := makeRequest(t, http.MethodPost, "/auth/register", body)
+    rr1 := httptest.NewRecorder()
+    handler.Register(rr1, req1)
 
-	// Register second time with same email
-	req2 := makeRequest(t, http.MethodPost, "/auth/register", body)
-	rr2 := httptest.NewRecorder()
-	handler.Register(rr2, req2)
+    // Register second time with same email
+    req2 := makeRequest(t, http.MethodPost, "/auth/register", body)
+    rr2 := httptest.NewRecorder()
+    handler.Register(rr2, req2)
 
-	if rr2.Code != http.StatusConflict {
-		t.Errorf("Expected status 409, got %d", rr2.Code)
-	}
+    if rr2.Code != http.StatusConflict {
+        t.Errorf("Expected status 409, got %d", rr2.Code)
+    }
 }
 
 // TestRegister_MissingFields verifies registration fails with missing required fields
 func TestRegister_MissingFields(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	body := map[string]string{
-		"email": "john@example.com",
-		// Missing name and password
-	}
+    body := map[string]string{
+        "email": "john@example.com",
+        // Missing name and password
+    }
 
-	req := makeRequest(t, http.MethodPost, "/auth/register", body)
-	rr := httptest.NewRecorder()
-	handler.Register(rr, req)
+    req := makeRequest(t, http.MethodPost, "/auth/register", body)
+    rr := httptest.NewRecorder()
+    handler.Register(rr, req)
 
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("Expected status 400, got %d", rr.Code)
-	}
+    if rr.Code != http.StatusBadRequest {
+        t.Errorf("Expected status 400, got %d", rr.Code)
+    }
 }
 
 // TestRegister_WeakPassword verifies weak passwords are rejected
 func TestRegister_WeakPassword(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	body := map[string]string{
-		"name":     "John Doe",
-		"email":    "john@example.com",
-		"password": "weak", // Too simple
-		"role":     "hiring_manager",
-	}
+    body := map[string]string{
+        "name":     "John Doe",
+        "email":    "john@example.com",
+        "password": "weak",
+    }
 
-	req := makeRequest(t, http.MethodPost, "/auth/register", body)
-	rr := httptest.NewRecorder()
-	handler.Register(rr, req)
+    req := makeRequest(t, http.MethodPost, "/auth/register", body)
+    rr := httptest.NewRecorder()
+    handler.Register(rr, req)
 
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("Expected status 400, got %d", rr.Code)
-	}
+    if rr.Code != http.StatusBadRequest {
+        t.Errorf("Expected status 400, got %d", rr.Code)
+    }
 }
 
 // TestRegister_InvalidEmail verifies invalid email format is rejected
 func TestRegister_InvalidEmail(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	body := map[string]string{
-		"name":     "John Doe",
-		"email":    "not-an-email",
-		"password": "SecurePass123!",
-		"role":     "hiring_manager",
-	}
+    body := map[string]string{
+        "name":     "John Doe",
+        "email":    "not-an-email",
+        "password": "SecurePass123!",
+    }
 
-	req := makeRequest(t, http.MethodPost, "/auth/register", body)
-	rr := httptest.NewRecorder()
-	handler.Register(rr, req)
+    req := makeRequest(t, http.MethodPost, "/auth/register", body)
+    rr := httptest.NewRecorder()
+    handler.Register(rr, req)
 
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("Expected status 400, got %d", rr.Code)
-	}
+    if rr.Code != http.StatusBadRequest {
+        t.Errorf("Expected status 400, got %d", rr.Code)
+    }
 }
 
 // ─── Login Tests ──────────────────────────────────────────────────────────────
 
 // TestLogin_Success verifies a registered user can login successfully
 func TestLogin_Success(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	// First register a user
-	registerBody := map[string]string{
-		"name":     "John Doe",
-		"email":    "john@example.com",
-		"password": "SecurePass123!",
-		"role":     "hiring_manager",
-	}
-	req := makeRequest(t, http.MethodPost, "/auth/register", registerBody)
-	rr := httptest.NewRecorder()
-	handler.Register(rr, req)
+    // First register a user
+    registerBody := map[string]string{
+        "name":     "John Doe",
+        "email":    "john@example.com",
+        "password": "SecurePass123!",
+    }
+    req := makeRequest(t, http.MethodPost, "/auth/register", registerBody)
+    rr := httptest.NewRecorder()
+    handler.Register(rr, req)
 
-	// Now login
-	loginBody := map[string]string{
-		"email":    "john@example.com",
-		"password": "SecurePass123!",
-	}
-	loginReq := makeRequest(t, http.MethodPost, "/auth/login", loginBody)
-	loginRR := httptest.NewRecorder()
-	handler.Login(loginRR, loginReq)
+    // Now login
+    loginBody := map[string]string{
+        "email":    "john@example.com",
+        "password": "SecurePass123!",
+    }
+    loginReq := makeRequest(t, http.MethodPost, "/auth/login", loginBody)
+    loginRR := httptest.NewRecorder()
+    handler.Login(loginRR, loginReq)
 
-	if loginRR.Code != http.StatusOK {
-		t.Errorf("Expected status 200, got %d. Body: %s", loginRR.Code, loginRR.Body.String())
-	}
+    if loginRR.Code != http.StatusOK {
+        t.Errorf("Expected status 200, got %d. Body: %s", loginRR.Code, loginRR.Body.String())
+    }
 
-	var response AuthResponse
-	if err := json.NewDecoder(loginRR.Body).Decode(&response); err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-	if response.AccessToken == "" {
-		t.Error("Expected access token in response, got empty string")
-	}
+    var response AuthResponse
+    if err := json.NewDecoder(loginRR.Body).Decode(&response); err != nil {
+        t.Fatalf("Failed to decode response: %v", err)
+    }
+    if response.AccessToken == "" {
+        t.Error("Expected access token in response, got empty string")
+    }
 }
 
 // TestLogin_WrongPassword verifies login fails with incorrect password
 func TestLogin_WrongPassword(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	// Register user
-	registerBody := map[string]string{
-		"name":     "John Doe",
-		"email":    "john@example.com",
-		"password": "SecurePass123!",
-		"role":     "hiring_manager",
-	}
-	req := makeRequest(t, http.MethodPost, "/auth/register", registerBody)
-	rr := httptest.NewRecorder()
-	handler.Register(rr, req)
+    // Register user
+    registerBody := map[string]string{
+        "name":     "John Doe",
+        "email":    "john@example.com",
+        "password": "SecurePass123!",
+    }
+    req := makeRequest(t, http.MethodPost, "/auth/register", registerBody)
+    rr := httptest.NewRecorder()
+    handler.Register(rr, req)
 
-	// Login with wrong password
-	loginBody := map[string]string{
-		"email":    "john@example.com",
-		"password": "WrongPass123!",
-	}
-	loginReq := makeRequest(t, http.MethodPost, "/auth/login", loginBody)
-	loginRR := httptest.NewRecorder()
-	handler.Login(loginRR, loginReq)
+    // Login with wrong password
+    loginBody := map[string]string{
+        "email":    "john@example.com",
+        "password": "WrongPass123!",
+    }
+    loginReq := makeRequest(t, http.MethodPost, "/auth/login", loginBody)
+    loginRR := httptest.NewRecorder()
+    handler.Login(loginRR, loginReq)
 
-	if loginRR.Code != http.StatusUnauthorized {
-		t.Errorf("Expected status 401, got %d", loginRR.Code)
-	}
+    if loginRR.Code != http.StatusUnauthorized {
+        t.Errorf("Expected status 401, got %d", loginRR.Code)
+    }
 }
 
 // TestLogin_UserNotFound verifies login fails for non-existent email
 func TestLogin_UserNotFound(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	loginBody := map[string]string{
-		"email":    "nobody@example.com",
-		"password": "SecurePass123!",
-	}
-	req := makeRequest(t, http.MethodPost, "/auth/login", loginBody)
-	rr := httptest.NewRecorder()
-	handler.Login(rr, req)
+    loginBody := map[string]string{
+        "email":    "nobody@example.com",
+        "password": "SecurePass123!",
+    }
+    req := makeRequest(t, http.MethodPost, "/auth/login", loginBody)
+    rr := httptest.NewRecorder()
+    handler.Login(rr, req)
 
-	if rr.Code != http.StatusUnauthorized {
-		t.Errorf("Expected status 401, got %d", rr.Code)
-	}
+    if rr.Code != http.StatusUnauthorized {
+        t.Errorf("Expected status 401, got %d", rr.Code)
+    }
 }
 
 // TestLogin_InactiveUser verifies deactivated users cannot login
 func TestLogin_InactiveUser(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	// Register user
-	registerBody := map[string]string{
-		"name":     "John Doe",
-		"email":    "john@example.com",
-		"password": "SecurePass123!",
-		"role":     "hiring_manager",
-	}
-	req := makeRequest(t, http.MethodPost, "/auth/register", registerBody)
-	rr := httptest.NewRecorder()
-	handler.Register(rr, req)
+    // Register user
+    registerBody := map[string]string{
+        "name":     "John Doe",
+        "email":    "john@example.com",
+        "password": "SecurePass123!",
+    }
+    req := makeRequest(t, http.MethodPost, "/auth/register", registerBody)
+    rr := httptest.NewRecorder()
+    handler.Register(rr, req)
 
-	// Deactivate user directly in DB
-	db.Model(&models.User{}).
-		Where("email = ?", "john@example.com").
-		Update("is_active", false)
+    // Deactivate user directly in DB
+    db.Model(&models.User{}).
+        Where("email = ?", "john@example.com").
+        Update("is_active", false)
 
-	// Try to login
-	loginBody := map[string]string{
-		"email":    "john@example.com",
-		"password": "SecurePass123!",
-	}
-	loginReq := makeRequest(t, http.MethodPost, "/auth/login", loginBody)
-	loginRR := httptest.NewRecorder()
-	handler.Login(loginRR, loginReq)
+    // Try to login
+    loginBody := map[string]string{
+        "email":    "john@example.com",
+        "password": "SecurePass123!",
+    }
+    loginReq := makeRequest(t, http.MethodPost, "/auth/login", loginBody)
+    loginRR := httptest.NewRecorder()
+    handler.Login(loginRR, loginReq)
 
-	if loginRR.Code != http.StatusForbidden {
-		t.Errorf("Expected status 403, got %d", loginRR.Code)
-	}
+    if loginRR.Code != http.StatusForbidden {
+        t.Errorf("Expected status 403, got %d", loginRR.Code)
+    }
 }
 
 // TestLogin_MissingFields verifies login fails with missing credentials
 func TestLogin_MissingFields(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	loginBody := map[string]string{
-		"email": "john@example.com",
-		// Missing password
-	}
-	req := makeRequest(t, http.MethodPost, "/auth/login", loginBody)
-	rr := httptest.NewRecorder()
-	handler.Login(rr, req)
+    loginBody := map[string]string{
+        "email": "john@example.com",
+        // Missing password
+    }
+    req := makeRequest(t, http.MethodPost, "/auth/login", loginBody)
+    rr := httptest.NewRecorder()
+    handler.Login(rr, req)
 
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("Expected status 400, got %d", rr.Code)
-	}
+    if rr.Code != http.StatusBadRequest {
+        t.Errorf("Expected status 400, got %d", rr.Code)
+    }
 }
 
 // ─── ForgotPassword Tests ─────────────────────────────────────────────────────
 
 // TestForgotPassword_ValidEmail verifies forgot password succeeds with valid email
 func TestForgotPassword_ValidEmail(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	// Register user first
-	registerBody := map[string]string{
-		"name":     "John Doe",
-		"email":    "john@example.com",
-		"password": "SecurePass123!",
-		"role":     "hiring_manager",
-	}
-	req := makeRequest(t, http.MethodPost, "/auth/register", registerBody)
-	rr := httptest.NewRecorder()
-	handler.Register(rr, req)
+    // Register user first
+    registerBody := map[string]string{
+        "name":     "John Doe",
+        "email":    "john@example.com",
+        "password": "SecurePass123!",
+    }
+    req := makeRequest(t, http.MethodPost, "/auth/register", registerBody)
+    rr := httptest.NewRecorder()
+    handler.Register(rr, req)
 
-	// Request password reset
-	forgotBody := map[string]string{"email": "john@example.com"}
-	forgotReq := makeRequest(t, http.MethodPost, "/auth/forgot-password", forgotBody)
-	forgotRR := httptest.NewRecorder()
-	handler.ForgotPassword(forgotRR, forgotReq)
+    // Request password reset
+    forgotBody := map[string]string{"email": "john@example.com"}
+    forgotReq := makeRequest(t, http.MethodPost, "/auth/forgot-password", forgotBody)
+    forgotRR := httptest.NewRecorder()
+    handler.ForgotPassword(forgotRR, forgotReq)
 
-	if forgotRR.Code != http.StatusOK {
-		t.Errorf("Expected status 200, got %d", forgotRR.Code)
-	}
+    if forgotRR.Code != http.StatusOK {
+        t.Errorf("Expected status 200, got %d", forgotRR.Code)
+    }
 
-	var response ForgotPasswordResponse
-	if err := json.NewDecoder(forgotRR.Body).Decode(&response); err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-	if response.ResetToken == "" {
-		t.Error("Expected reset token in response, got empty string")
-	}
+    var response ForgotPasswordResponse
+    if err := json.NewDecoder(forgotRR.Body).Decode(&response); err != nil {
+        t.Fatalf("Failed to decode response: %v", err)
+    }
+    if response.ResetToken == "" {
+        t.Error("Expected reset token in response, got empty string")
+    }
 }
 
 // TestForgotPassword_MissingEmail verifies forgot password fails with missing email
 func TestForgotPassword_MissingEmail(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	forgotBody := map[string]string{}
-	req := makeRequest(t, http.MethodPost, "/auth/forgot-password", forgotBody)
-	rr := httptest.NewRecorder()
-	handler.ForgotPassword(rr, req)
+    forgotBody := map[string]string{}
+    req := makeRequest(t, http.MethodPost, "/auth/forgot-password", forgotBody)
+    rr := httptest.NewRecorder()
+    handler.ForgotPassword(rr, req)
 
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("Expected status 400, got %d", rr.Code)
-	}
+    if rr.Code != http.StatusBadRequest {
+        t.Errorf("Expected status 400, got %d", rr.Code)
+    }
 }
 
 // ─── ResetPassword Tests ──────────────────────────────────────────────────────
 
 // TestResetPassword_ValidToken verifies password reset succeeds with valid token
 func TestResetPassword_ValidToken(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	// Register user
-	registerBody := map[string]string{
-		"name":     "John Doe",
-		"email":    "john@example.com",
-		"password": "SecurePass123!",
-		"role":     "hiring_manager",
-	}
-	req := makeRequest(t, http.MethodPost, "/auth/register", registerBody)
-	rr := httptest.NewRecorder()
-	handler.Register(rr, req)
+    // Register user
+    registerBody := map[string]string{
+        "name":     "John Doe",
+        "email":    "john@example.com",
+        "password": "SecurePass123!",
+    }
+    req := makeRequest(t, http.MethodPost, "/auth/register", registerBody)
+    rr := httptest.NewRecorder()
+    handler.Register(rr, req)
 
-	// Get reset token
-	forgotBody := map[string]string{"email": "john@example.com"}
-	forgotReq := makeRequest(t, http.MethodPost, "/auth/forgot-password", forgotBody)
-	forgotRR := httptest.NewRecorder()
-	handler.ForgotPassword(forgotRR, forgotReq)
+    // Get reset token
+    forgotBody := map[string]string{"email": "john@example.com"}
+    forgotReq := makeRequest(t, http.MethodPost, "/auth/forgot-password", forgotBody)
+    forgotRR := httptest.NewRecorder()
+    handler.ForgotPassword(forgotRR, forgotReq)
 
-	var forgotResponse ForgotPasswordResponse
-	json.NewDecoder(forgotRR.Body).Decode(&forgotResponse)
+    var forgotResponse ForgotPasswordResponse
+    json.NewDecoder(forgotRR.Body).Decode(&forgotResponse)
 
-	// Reset password with valid token
-	resetBody := map[string]string{
-		"token":    forgotResponse.ResetToken,
-		"password": "NewSecurePass123!",
-	}
-	resetReq := makeRequest(t, http.MethodPost, "/auth/reset-password", resetBody)
-	resetRR := httptest.NewRecorder()
-	handler.ResetPassword(resetRR, resetReq)
+    // Reset password with valid token
+    resetBody := map[string]string{
+        "token":    forgotResponse.ResetToken,
+        "password": "NewSecurePass123!",
+    }
+    resetReq := makeRequest(t, http.MethodPost, "/auth/reset-password", resetBody)
+    resetRR := httptest.NewRecorder()
+    handler.ResetPassword(resetRR, resetReq)
 
-	if resetRR.Code != http.StatusOK {
-		t.Errorf("Expected status 200, got %d. Body: %s", resetRR.Code, resetRR.Body.String())
-	}
+    if resetRR.Code != http.StatusOK {
+        t.Errorf("Expected status 200, got %d. Body: %s", resetRR.Code, resetRR.Body.String())
+    }
 }
 
 // TestResetPassword_InvalidToken verifies reset fails with invalid token
 func TestResetPassword_InvalidToken(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	resetBody := map[string]string{
-		"token":    "invalid-token-that-doesnt-exist",
-		"password": "NewSecurePass123!",
-	}
-	req := makeRequest(t, http.MethodPost, "/auth/reset-password", resetBody)
-	rr := httptest.NewRecorder()
-	handler.ResetPassword(rr, req)
+    resetBody := map[string]string{
+        "token":    "invalid-token-that-doesnt-exist",
+        "password": "NewSecurePass123!",
+    }
+    req := makeRequest(t, http.MethodPost, "/auth/reset-password", resetBody)
+    rr := httptest.NewRecorder()
+    handler.ResetPassword(rr, req)
 
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("Expected status 400, got %d", rr.Code)
-	}
+    if rr.Code != http.StatusBadRequest {
+        t.Errorf("Expected status 400, got %d", rr.Code)
+    }
 }
 
 // TestResetPassword_WeakPassword verifies reset fails with weak new password
 func TestResetPassword_WeakPassword(t *testing.T) {
-	db := setupTestDB(t)
-	handler := &AuthHandler{DB: db}
+    db := setupTestDB(t)
+    handler := &AuthHandler{DB: db}
 
-	resetBody := map[string]string{
-		"token":    "some-token",
-		"password": "weak",
-	}
-	req := makeRequest(t, http.MethodPost, "/auth/reset-password", resetBody)
-	rr := httptest.NewRecorder()
-	handler.ResetPassword(rr, req)
+    resetBody := map[string]string{
+        "token":    "some-token",
+        "password": "weak",
+    }
+    req := makeRequest(t, http.MethodPost, "/auth/reset-password", resetBody)
+    rr := httptest.NewRecorder()
+    handler.ResetPassword(rr, req)
 
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("Expected status 400, got %d", rr.Code)
-	}
+    if rr.Code != http.StatusBadRequest {
+        t.Errorf("Expected status 400, got %d", rr.Code)
+    }
 }

--- a/backend/handlers/dashboard_handler.go
+++ b/backend/handlers/dashboard_handler.go
@@ -1,0 +1,121 @@
+package handlers
+
+import (
+    "encoding/json"
+    "net/http"
+
+    "backend/models"
+
+    "gorm.io/gorm"
+)
+
+// DashboardHandler encapsulates database dependency for dashboard operations
+type DashboardHandler struct {
+    DB *gorm.DB
+}
+
+// DepartmentSummary represents job counts per department
+// Used in dashboard stats to show hiring activity by department
+type DepartmentSummary struct {
+    Department string `json:"department"`
+    OpenCount  int64  `json:"openCount"`
+    ClosedCount int64 `json:"closedCount"`
+}
+
+// DashboardStatsResponse is the complete dashboard stats response shape
+// Field names are camelCase to match Angular frontend conventions (confirmed with Vardhan)
+type DashboardStatsResponse struct {
+    TotalJobs         int64               `json:"totalJobs"`
+    OpenJobs          int64               `json:"openJobs"`
+    ClosedJobs        int64               `json:"closedJobs"`
+    TotalCandidates   int64               `json:"totalCandidates"`
+    TotalUsers        int64               `json:"totalUsers"`
+    DepartmentSummary []DepartmentSummary `json:"departmentSummary"`
+}
+
+// GetDashboardStats handles GET /dashboard/stats
+// Returns aggregated stats for the hiring dashboard
+// Accessible by: admin, hiring_manager, interviewer (NOT candidate)
+func (h *DashboardHandler) GetDashboardStats(w http.ResponseWriter, r *http.Request) {
+    var stats DashboardStatsResponse
+
+    // Count total jobs
+    if err := h.DB.Model(&models.Job{}).Count(&stats.TotalJobs).Error; err != nil {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusInternalServerError)
+        json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve dashboard stats"})
+        return
+    }
+
+    // Count open jobs (status = 'Open')
+    if err := h.DB.Model(&models.Job{}).Where("status = ?", "Open").Count(&stats.OpenJobs).Error; err != nil {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusInternalServerError)
+        json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve dashboard stats"})
+        return
+    }
+
+    // Count closed jobs (status = 'Closed')
+    if err := h.DB.Model(&models.Job{}).Where("status = ?", "Closed").Count(&stats.ClosedJobs).Error; err != nil {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusInternalServerError)
+        json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve dashboard stats"})
+        return
+    }
+
+    // Count total candidates from applications table
+    // Excludes WITHDRAWN applications as confirmed with Vardhan
+    if err := h.DB.Model(&models.Application{}).
+        Where("status != ?", "WITHDRAWN").
+        Count(&stats.TotalCandidates).Error; err != nil {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusInternalServerError)
+        json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve dashboard stats"})
+        return
+    }
+
+    // Count total users
+    if err := h.DB.Model(&models.User{}).Count(&stats.TotalUsers).Error; err != nil {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusInternalServerError)
+        json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve dashboard stats"})
+        return
+    }
+
+    // Build department summary using GROUP BY query
+    // Counts open and closed jobs per department
+    type deptRow struct {
+        Department string
+        Status     string
+        Count      int64
+    }
+    var rows []deptRow
+    h.DB.Model(&models.Job{}).
+        Select("department, status, COUNT(*) as count").
+        Group("department, status").
+        Scan(&rows)
+
+    // Aggregate department counts into map then convert to slice
+    deptMap := make(map[string]*DepartmentSummary)
+    for _, row := range rows {
+        if _, exists := deptMap[row.Department]; !exists {
+            deptMap[row.Department] = &DepartmentSummary{Department: row.Department}
+        }
+        if row.Status == "Open" {
+            deptMap[row.Department].OpenCount = row.Count
+        } else if row.Status == "Closed" {
+            deptMap[row.Department].ClosedCount = row.Count
+        }
+    }
+
+    // Convert map to slice for JSON response
+    stats.DepartmentSummary = make([]DepartmentSummary, 0, len(deptMap))
+    for _, dept := range deptMap {
+        stats.DepartmentSummary = append(stats.DepartmentSummary, *dept)
+    }
+
+    // Return dashboard stats as JSON with 200 OK
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    json.NewEncoder(w).Encode(stats)
+}

--- a/backend/handlers/dashboard_handler.go
+++ b/backend/handlers/dashboard_handler.go
@@ -17,9 +17,9 @@ type DashboardHandler struct {
 // DepartmentSummary represents job counts per department
 // Used in dashboard stats to show hiring activity by department
 type DepartmentSummary struct {
-    Department string `json:"department"`
-    OpenCount  int64  `json:"openCount"`
-    ClosedCount int64 `json:"closedCount"`
+    Department  string `json:"department"`
+    OpenCount   int64  `json:"openCount"`
+    ClosedCount int64  `json:"closedCount"`
 }
 
 // DashboardStatsResponse is the complete dashboard stats response shape
@@ -96,14 +96,16 @@ func (h *DashboardHandler) GetDashboardStats(w http.ResponseWriter, r *http.Requ
         Scan(&rows)
 
     // Aggregate department counts into map then convert to slice
+    // Uses tagged switch on row.Status for cleaner code (QF1003)
     deptMap := make(map[string]*DepartmentSummary)
     for _, row := range rows {
         if _, exists := deptMap[row.Department]; !exists {
             deptMap[row.Department] = &DepartmentSummary{Department: row.Department}
         }
-        if row.Status == "Open" {
+        switch row.Status {
+        case "Open":
             deptMap[row.Department].OpenCount = row.Count
-        } else if row.Status == "Closed" {
+        case "Closed":
             deptMap[row.Department].ClosedCount = row.Count
         }
     }

--- a/backend/handlers/dashboard_handler_test.go
+++ b/backend/handlers/dashboard_handler_test.go
@@ -1,0 +1,224 @@
+package handlers
+
+import (
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "backend/models"
+)
+
+// setupDashboardTestDB creates an in-memory SQLite database with all dashboard-related tables
+func setupDashboardTestDB(t *testing.T) *DashboardHandler {
+    db := setupTestDB(t)
+    if err := db.AutoMigrate(&models.Job{}, &models.Application{}, &models.Candidate{}); err != nil {
+        t.Fatalf("Failed to migrate dashboard test database: %v", err)
+    }
+    return &DashboardHandler{DB: db}
+}
+
+// ─── GetDashboardStats Tests ──────────────────────────────────────────────────
+
+// TestGetDashboardStats_EmptyDatabase verifies stats return zeros when no data exists
+func TestGetDashboardStats_EmptyDatabase(t *testing.T) {
+    handler := setupDashboardTestDB(t)
+
+    req, _ := http.NewRequest(http.MethodGet, "/dashboard/stats", nil)
+    req = injectAdminClaims(req)
+    rr := httptest.NewRecorder()
+    handler.GetDashboardStats(rr, req)
+
+    if rr.Code != http.StatusOK {
+        t.Errorf("Expected status 200, got %d. Body: %s", rr.Code, rr.Body.String())
+    }
+
+    var stats DashboardStatsResponse
+    if err := json.NewDecoder(rr.Body).Decode(&stats); err != nil {
+        t.Fatalf("Failed to decode response: %v", err)
+    }
+
+    if stats.TotalJobs != 0 {
+        t.Errorf("Expected totalJobs 0, got %d", stats.TotalJobs)
+    }
+    if stats.TotalUsers != 0 {
+        t.Errorf("Expected totalUsers 0, got %d", stats.TotalUsers)
+    }
+    if stats.TotalCandidates != 0 {
+        t.Errorf("Expected totalCandidates 0, got %d", stats.TotalCandidates)
+    }
+    if stats.DepartmentSummary == nil {
+        t.Error("Expected departmentSummary to be empty slice, got nil")
+    }
+}
+
+// TestGetDashboardStats_TotalJobsCount verifies correct total job count
+func TestGetDashboardStats_TotalJobsCount(t *testing.T) {
+    handler := setupDashboardTestDB(t)
+
+    // Create 3 jobs
+    for i := 0; i < 3; i++ {
+        handler.DB.Create(&models.Job{Title: "Engineer", Status: "Open", Department: "Engineering"})
+    }
+
+    req, _ := http.NewRequest(http.MethodGet, "/dashboard/stats", nil)
+    req = injectAdminClaims(req)
+    rr := httptest.NewRecorder()
+    handler.GetDashboardStats(rr, req)
+
+    var stats DashboardStatsResponse
+    json.NewDecoder(rr.Body).Decode(&stats)
+
+    if stats.TotalJobs != 3 {
+        t.Errorf("Expected totalJobs 3, got %d", stats.TotalJobs)
+    }
+}
+
+// TestGetDashboardStats_OpenClosedJobsCount verifies open and closed job counts
+func TestGetDashboardStats_OpenClosedJobsCount(t *testing.T) {
+    handler := setupDashboardTestDB(t)
+
+    // Create 2 open and 1 closed job
+    handler.DB.Create(&models.Job{Title: "Engineer 1", Status: "Open", Department: "Engineering"})
+    handler.DB.Create(&models.Job{Title: "Engineer 2", Status: "Open", Department: "Engineering"})
+    handler.DB.Create(&models.Job{Title: "Designer", Status: "Closed", Department: "Design"})
+
+    req, _ := http.NewRequest(http.MethodGet, "/dashboard/stats", nil)
+    req = injectAdminClaims(req)
+    rr := httptest.NewRecorder()
+    handler.GetDashboardStats(rr, req)
+
+    var stats DashboardStatsResponse
+    json.NewDecoder(rr.Body).Decode(&stats)
+
+    if stats.OpenJobs != 2 {
+        t.Errorf("Expected openJobs 2, got %d", stats.OpenJobs)
+    }
+    if stats.ClosedJobs != 1 {
+        t.Errorf("Expected closedJobs 1, got %d", stats.ClosedJobs)
+    }
+    if stats.TotalJobs != 3 {
+        t.Errorf("Expected totalJobs 3, got %d", stats.TotalJobs)
+    }
+}
+
+// TestGetDashboardStats_TotalCandidatesExcludesWithdrawn verifies withdrawn applications excluded
+func TestGetDashboardStats_TotalCandidatesExcludesWithdrawn(t *testing.T) {
+    handler := setupDashboardTestDB(t)
+
+    // Create 3 applications: 2 active, 1 withdrawn
+    handler.DB.Create(&models.Application{Status: "APPLIED"})
+    handler.DB.Create(&models.Application{Status: "APPLIED"})
+    handler.DB.Create(&models.Application{Status: "WITHDRAWN"}) // Should be excluded
+
+    req, _ := http.NewRequest(http.MethodGet, "/dashboard/stats", nil)
+    req = injectAdminClaims(req)
+    rr := httptest.NewRecorder()
+    handler.GetDashboardStats(rr, req)
+
+    var stats DashboardStatsResponse
+    json.NewDecoder(rr.Body).Decode(&stats)
+
+    if stats.TotalCandidates != 2 {
+        t.Errorf("Expected totalCandidates 2 (excluding withdrawn), got %d", stats.TotalCandidates)
+    }
+}
+
+// TestGetDashboardStats_TotalUsersCount verifies correct user count
+func TestGetDashboardStats_TotalUsersCount(t *testing.T) {
+    handler := setupDashboardTestDB(t)
+
+    // Create 2 users
+    user1 := models.User{Name: "User One", Email: "user1@example.com", Role: "hiring_manager", IsActive: true}
+    user1.HashPassword("SecurePass123!")
+    handler.DB.Create(&user1)
+
+    user2 := models.User{Name: "User Two", Email: "user2@example.com", Role: "interviewer", IsActive: true}
+    user2.HashPassword("SecurePass123!")
+    handler.DB.Create(&user2)
+
+    req, _ := http.NewRequest(http.MethodGet, "/dashboard/stats", nil)
+    req = injectAdminClaims(req)
+    rr := httptest.NewRecorder()
+    handler.GetDashboardStats(rr, req)
+
+    var stats DashboardStatsResponse
+    json.NewDecoder(rr.Body).Decode(&stats)
+
+    if stats.TotalUsers != 2 {
+        t.Errorf("Expected totalUsers 2, got %d", stats.TotalUsers)
+    }
+}
+
+// TestGetDashboardStats_DepartmentSummary verifies department summary is correct
+func TestGetDashboardStats_DepartmentSummary(t *testing.T) {
+    handler := setupDashboardTestDB(t)
+
+    // Create jobs in different departments
+    handler.DB.Create(&models.Job{Title: "Eng 1", Status: "Open", Department: "Engineering"})
+    handler.DB.Create(&models.Job{Title: "Eng 2", Status: "Open", Department: "Engineering"})
+    handler.DB.Create(&models.Job{Title: "Eng 3", Status: "Closed", Department: "Engineering"})
+    handler.DB.Create(&models.Job{Title: "Design 1", Status: "Open", Department: "Design"})
+
+    req, _ := http.NewRequest(http.MethodGet, "/dashboard/stats", nil)
+    req = injectAdminClaims(req)
+    rr := httptest.NewRecorder()
+    handler.GetDashboardStats(rr, req)
+
+    var stats DashboardStatsResponse
+    json.NewDecoder(rr.Body).Decode(&stats)
+
+    if len(stats.DepartmentSummary) != 2 {
+        t.Errorf("Expected 2 departments, got %d", len(stats.DepartmentSummary))
+    }
+
+    // Find Engineering department
+    var engineering *DepartmentSummary
+    for i := range stats.DepartmentSummary {
+        if stats.DepartmentSummary[i].Department == "Engineering" {
+            engineering = &stats.DepartmentSummary[i]
+        }
+    }
+
+    if engineering == nil {
+        t.Fatal("Engineering department not found in summary")
+    }
+    if engineering.OpenCount != 2 {
+        t.Errorf("Expected Engineering openCount 2, got %d", engineering.OpenCount)
+    }
+    if engineering.ClosedCount != 1 {
+        t.Errorf("Expected Engineering closedCount 1, got %d", engineering.ClosedCount)
+    }
+}
+
+// TestGetDashboardStats_ResponseShape verifies exact JSON field names match frontend expectation
+func TestGetDashboardStats_ResponseShape(t *testing.T) {
+    handler := setupDashboardTestDB(t)
+
+    req, _ := http.NewRequest(http.MethodGet, "/dashboard/stats", nil)
+    req = injectAdminClaims(req)
+    rr := httptest.NewRecorder()
+    handler.GetDashboardStats(rr, req)
+
+    // Decode into raw map to verify exact camelCase field names
+    var raw map[string]interface{}
+    if err := json.NewDecoder(rr.Body).Decode(&raw); err != nil {
+        t.Fatalf("Failed to decode response: %v", err)
+    }
+
+    // Verify all required camelCase fields exist (confirmed with Vardhan)
+    requiredFields := []string{
+        "totalJobs",
+        "openJobs",
+        "closedJobs",
+        "totalCandidates",
+        "totalUsers",
+        "departmentSummary",
+    }
+
+    for _, field := range requiredFields {
+        if _, exists := raw[field]; !exists {
+            t.Errorf("Expected field '%s' in response, not found", field)
+        }
+    }
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -27,7 +27,8 @@ func main() {
 
 	// Seed default users if they don't exist
 	seeder.SeedAdmin(db)
-	seeder.SeedCandidate(db) // ← ADDED: Test candidate for E2E testing
+	seeder.SeedCandidate(db)
+	seeder.SeedHiringManager(db) // ← ADDED: Test hiring manager for E2E testing
 
 	// Setup routes with CORS middleware
 	handler := routes.SetupRoutes(db)

--- a/backend/main.go
+++ b/backend/main.go
@@ -25,10 +25,9 @@ func main() {
 		log.Fatal("failed to migrate database:", err)
 	}
 
-	// Seed default admin user if none exists
+	// Seed default users if they don't exist
 	seeder.SeedAdmin(db)
-	// Sample jobs / candidates / applications when DB has no jobs yet
-	seeder.SeedDemoData(db)
+	seeder.SeedCandidate(db) // ← ADDED: Test candidate for E2E testing
 
 	// Setup routes with CORS middleware
 	handler := routes.SetupRoutes(db)

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -1,58 +1,63 @@
 package routes
 
 import (
-	"backend/handlers"
-	"backend/middleware"
-	"net/http"
+    "backend/handlers"
+    "backend/middleware"
+    "net/http"
 
-	"github.com/gorilla/mux"
-	"gorm.io/gorm"
+    "github.com/gorilla/mux"
+    "gorm.io/gorm"
 )
 
 // SetupRoutes configures all application routes
 func SetupRoutes(db *gorm.DB) http.Handler {
-	router := mux.NewRouter()
+    router := mux.NewRouter()
 
-	// Health check endpoint (public)
-	router.HandleFunc("/health", handlers.HealthHandler).Methods("GET")
+    // Health check endpoint (public)
+    router.HandleFunc("/health", handlers.HealthHandler).Methods("GET")
 
-	// Authentication endpoints (public - no auth required)
-	authHandler := &handlers.AuthHandler{DB: db}
-	router.HandleFunc("/auth/register", authHandler.Register).Methods("POST")
-	router.HandleFunc("/auth/login", authHandler.Login).Methods("POST")
-	router.HandleFunc("/auth/forgot-password", authHandler.ForgotPassword).Methods("POST")
-	router.HandleFunc("/auth/reset-password", authHandler.ResetPassword).Methods("POST")
+    // Authentication endpoints (public - no auth required)
+    authHandler := &handlers.AuthHandler{DB: db}
+    router.HandleFunc("/auth/register", authHandler.Register).Methods("POST")
+    router.HandleFunc("/auth/login", authHandler.Login).Methods("POST")
+    router.HandleFunc("/auth/forgot-password", authHandler.ForgotPassword).Methods("POST")
+    router.HandleFunc("/auth/reset-password", authHandler.ResetPassword).Methods("POST")
 
-	// Admin user management (JWT + admin role required)
-	userHandler := &handlers.UserHandler{DB: db}
-	router.HandleFunc("/users", middleware.RequireAuth(middleware.RequireAdmin(userHandler.ListUsers))).Methods("GET")
-	router.HandleFunc("/users", middleware.RequireAuth(middleware.RequireAdmin(userHandler.CreateUser))).Methods("POST")
-	router.HandleFunc("/users/{id}", middleware.RequireAuth(middleware.RequireAdmin(userHandler.SetUserActive))).Methods("PATCH")
+    // Admin user management (JWT + admin role required)
+    userHandler := &handlers.UserHandler{DB: db}
+    router.HandleFunc("/users", middleware.RequireAuth(middleware.RequireAdmin(userHandler.ListUsers))).Methods("GET")
+    router.HandleFunc("/users", middleware.RequireAuth(middleware.RequireAdmin(userHandler.CreateUser))).Methods("POST")
+    router.HandleFunc("/users/{id}", middleware.RequireAuth(middleware.RequireAdmin(userHandler.SetUserActive))).Methods("PATCH")
 
-	// Job endpoints
-	jobHandler := &handlers.JobHandler{DB: db}
+    // Dashboard stats endpoint (JWT required, all roles except candidate)
+    dashboardHandler := &handlers.DashboardHandler{DB: db}
+    router.HandleFunc("/dashboard/stats",
+        middleware.RequireAuth(
+            middleware.RequireRole("admin", "hiring_manager", "interviewer")(dashboardHandler.GetDashboardStats),
+        ),
+    ).Methods("GET")
 
-	// Public job viewing (auth required, any role)
-	router.HandleFunc("/jobs", middleware.RequireAuth(jobHandler.GetAllJobs)).Methods("GET")
-	router.HandleFunc("/jobs/{id}", middleware.RequireAuth(jobHandler.GetJobByID)).Methods("GET")
+    // Job endpoints
+    jobHandler := &handlers.JobHandler{DB: db}
 
-	// Protected job management (hiring_manager or admin only)
-	router.HandleFunc("/jobs", middleware.RequireAuth(middleware.RequireRole("hiring_manager", "admin")(jobHandler.CreateJob))).Methods("POST")
-	router.HandleFunc("/jobs/{id}", middleware.RequireAuth(middleware.RequireRole("hiring_manager", "admin")(jobHandler.UpdateJob))).Methods("PUT")
-	router.HandleFunc("/jobs/{id}", middleware.RequireAuth(middleware.RequireRole("hiring_manager", "admin")(jobHandler.DeleteJob))).Methods("DELETE")
+    // Public job viewing (auth required, any role)
+    router.HandleFunc("/jobs", middleware.RequireAuth(jobHandler.GetAllJobs)).Methods("GET")
+    router.HandleFunc("/jobs/{id}", middleware.RequireAuth(jobHandler.GetJobByID)).Methods("GET")
 
-	// ---------------------------
-	// Candidate API endpoints (BE-2)
-	// ---------------------------
-	candidateHandler := &handlers.CandidateHandler{DB: db}
-	router.HandleFunc("/api/candidate/apply", middleware.RequireAuth(candidateHandler.ApplyWithCandidate)).Methods("POST")
-	router.HandleFunc("/api/candidate/jobs/{jobId}/applications", middleware.RequireAuth(candidateHandler.ListApplicationsByJob)).Methods("GET")
-	router.HandleFunc("/api/candidate/applications/{id}/stage", middleware.RequireAuth(candidateHandler.UpdateApplicationStage)).Methods("PATCH")
-	router.HandleFunc("/api/candidate/applications", candidateHandler.GetApplications).Methods("GET")
-	router.HandleFunc("/api/candidate/me/applications", middleware.RequireAuth(middleware.RequireRole("candidate")(candidateHandler.ListMyApplications))).Methods("GET")
-	router.HandleFunc("/api/candidate/applications/{id}/withdraw", middleware.RequireAuth(middleware.RequireRole("candidate")(candidateHandler.WithdrawApplication))).Methods("PATCH")
+    // Protected job management (hiring_manager or admin only)
+    router.HandleFunc("/jobs", middleware.RequireAuth(middleware.RequireRole("hiring_manager", "admin")(jobHandler.CreateJob))).Methods("POST")
+    router.HandleFunc("/jobs/{id}", middleware.RequireAuth(middleware.RequireRole("hiring_manager", "admin")(jobHandler.UpdateJob))).Methods("PUT")
+    router.HandleFunc("/jobs/{id}", middleware.RequireAuth(middleware.RequireRole("hiring_manager", "admin")(jobHandler.DeleteJob))).Methods("DELETE")
 
-	// Apply CORS middleware
-	corsHandler := middleware.SetupCORS()
-	return corsHandler(router)
+    // ---------------------------
+    // Candidate API endpoints (BE-2)
+    // ---------------------------
+    candidateHandler := &handlers.CandidateHandler{DB: db}
+    router.HandleFunc("/api/candidate/apply", candidateHandler.ApplyToJob).Methods("POST")
+    router.HandleFunc("/api/candidate/applications", candidateHandler.GetApplications).Methods("GET")
+    router.HandleFunc("/api/candidate/applications/{id}/withdraw", candidateHandler.WithdrawApplication).Methods("PATCH")
+
+    // Apply CORS middleware
+    corsHandler := middleware.SetupCORS()
+    return corsHandler(router)
 }

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -40,21 +40,37 @@ func SetupRoutes(db *gorm.DB) http.Handler {
     // Job endpoints
     jobHandler := &handlers.JobHandler{DB: db}
 
-    // Public job viewing (auth required, any role)
+    // Job viewing (auth required, any role)
     router.HandleFunc("/jobs", middleware.RequireAuth(jobHandler.GetAllJobs)).Methods("GET")
     router.HandleFunc("/jobs/{id}", middleware.RequireAuth(jobHandler.GetJobByID)).Methods("GET")
 
-    // Protected job management (hiring_manager or admin only)
+    // Job management (hiring_manager or admin only)
     router.HandleFunc("/jobs", middleware.RequireAuth(middleware.RequireRole("hiring_manager", "admin")(jobHandler.CreateJob))).Methods("POST")
     router.HandleFunc("/jobs/{id}", middleware.RequireAuth(middleware.RequireRole("hiring_manager", "admin")(jobHandler.UpdateJob))).Methods("PUT")
     router.HandleFunc("/jobs/{id}", middleware.RequireAuth(middleware.RequireRole("hiring_manager", "admin")(jobHandler.DeleteJob))).Methods("DELETE")
 
     // ---------------------------
     // Candidate API endpoints (BE-2)
+    // Updated to match BE-2's current method names
     // ---------------------------
     candidateHandler := &handlers.CandidateHandler{DB: db}
-    router.HandleFunc("/api/candidate/apply", candidateHandler.ApplyToJob).Methods("POST")
+
+    // Apply to job (creates or reuses candidate by email)
+    router.HandleFunc("/api/candidate/apply", candidateHandler.ApplyWithCandidate).Methods("POST")
+
+    // List applications for a specific job (hiring pipeline view)
+    router.HandleFunc("/api/jobs/{jobId}/applications", candidateHandler.ListApplicationsByJob).Methods("GET")
+
+    // Update application stage (pipeline stage movement)
+    router.HandleFunc("/api/applications/{id}/stage", candidateHandler.UpdateApplicationStage).Methods("PATCH")
+
+    // Legacy: list applications by candidate_id query param
     router.HandleFunc("/api/candidate/applications", candidateHandler.GetApplications).Methods("GET")
+
+    // Candidate portal: list my applications (JWT required)
+    router.HandleFunc("/api/candidate/my-applications", candidateHandler.ListMyApplications).Methods("GET")
+
+    // Candidate portal: withdraw application (JWT required, must own application)
     router.HandleFunc("/api/candidate/applications/{id}/withdraw", candidateHandler.WithdrawApplication).Methods("PATCH")
 
     // Apply CORS middleware

--- a/backend/seeder/seeder.go
+++ b/backend/seeder/seeder.go
@@ -1,54 +1,96 @@
 package seeder
 
 import (
-	"backend/models"
-	"log"
+    "backend/models"
+    "log"
 
-	"gorm.io/gorm"
+    "gorm.io/gorm"
 )
 
-// DefaultAdminEmail is the default admin credentials for development/testing
+// Default credentials for development/testing
 // IMPORTANT: Change these credentials in production!
 const (
-	DefaultAdminEmail    = "admin@hireflow.com"
-	DefaultAdminPassword = "Admin@1234"
-	DefaultAdminName     = "System Admin"
+    DefaultAdminEmail    = "admin@hireflow.com"
+    DefaultAdminPassword = "Admin@1234"
+    DefaultAdminName     = "System Admin"
+
+    DefaultCandidateEmail    = "candidate@hireflow.com"
+    DefaultCandidatePassword = "Candidate@1234"
+    DefaultCandidateName     = "Test Candidate"
 )
 
 // SeedAdmin creates a default admin user if none exists.
 // Safe to call on every startup - skips if admin already exists.
 func SeedAdmin(db *gorm.DB) {
-	var count int64
-	db.Model(&models.User{}).Where("role = ?", "admin").Count(&count)
+    var count int64
+    db.Model(&models.User{}).Where("role = ?", "admin").Count(&count)
 
-	// Admin already exists - skip seeding
-	if count > 0 {
-		log.Println("Admin user already exists - skipping seed")
-		return
-	}
+    // Admin already exists - skip seeding
+    if count > 0 {
+        log.Println("Admin user already exists - skipping seed")
+        return
+    }
 
-	// Create default admin user
-	admin := models.User{
-		Name:     DefaultAdminName,
-		Email:    DefaultAdminEmail,
-		Role:     "admin",
-		IsActive: true,
-	}
+    // Create default admin user
+    admin := models.User{
+        Name:     DefaultAdminName,
+        Email:    DefaultAdminEmail,
+        Role:     "admin",
+        IsActive: true,
+    }
 
-	// Hash default password
-	if err := admin.HashPassword(DefaultAdminPassword); err != nil {
-		log.Printf("Failed to hash admin password: %v", err)
-		return
-	}
+    // Hash default password
+    if err := admin.HashPassword(DefaultAdminPassword); err != nil {
+        log.Printf("Failed to hash admin password: %v", err)
+        return
+    }
 
-	// Save admin to database
-	if err := db.Create(&admin).Error; err != nil {
-		log.Printf("Failed to create admin user: %v", err)
-		return
-	}
+    // Save admin to database
+    if err := db.Create(&admin).Error; err != nil {
+        log.Printf("Failed to create admin user: %v", err)
+        return
+    }
 
-	log.Println("✅ Default admin user created successfully")
-	log.Printf("   Email:    %s", DefaultAdminEmail)
-	log.Printf("   Password: %s", DefaultAdminPassword)
-	log.Println("   ⚠️  Change these credentials in production!")
+    log.Println("✅ Default admin user created successfully")
+    log.Printf("   Email:    %s", DefaultAdminEmail)
+    log.Printf("   Password: %s", DefaultAdminPassword)
+    log.Println("   ⚠️  Change these credentials in production!")
+}
+
+// SeedCandidate creates a default candidate user for E2E testing.
+// Safe to call on every startup - skips if candidate already exists.
+func SeedCandidate(db *gorm.DB) {
+    var count int64
+    db.Model(&models.User{}).Where("email = ?", DefaultCandidateEmail).Count(&count)
+
+    // Candidate already exists - skip seeding
+    if count > 0 {
+        log.Println("Test candidate user already exists - skipping seed")
+        return
+    }
+
+    // Create default candidate user
+    candidate := models.User{
+        Name:     DefaultCandidateName,
+        Email:    DefaultCandidateEmail,
+        Role:     "candidate",
+        IsActive: true,
+    }
+
+    // Hash default password
+    if err := candidate.HashPassword(DefaultCandidatePassword); err != nil {
+        log.Printf("Failed to hash candidate password: %v", err)
+        return
+    }
+
+    // Save candidate to database
+    if err := db.Create(&candidate).Error; err != nil {
+        log.Printf("Failed to create candidate user: %v", err)
+        return
+    }
+
+    log.Println("✅ Default candidate user created successfully")
+    log.Printf("   Email:    %s", DefaultCandidateEmail)
+    log.Printf("   Password: %s", DefaultCandidatePassword)
+    log.Println("   ⚠️  For testing only - not for production use!")
 }

--- a/backend/seeder/seeder.go
+++ b/backend/seeder/seeder.go
@@ -1,96 +1,126 @@
 package seeder
 
 import (
-    "backend/models"
-    "log"
+	"backend/models"
+	"log"
 
-    "gorm.io/gorm"
+	"gorm.io/gorm"
 )
 
 // Default credentials for development/testing
 // IMPORTANT: Change these credentials in production!
 const (
-    DefaultAdminEmail    = "admin@hireflow.com"
-    DefaultAdminPassword = "Admin@1234"
-    DefaultAdminName     = "System Admin"
+	DefaultAdminEmail    = "admin@hireflow.com"
+	DefaultAdminPassword = "Admin@1234"
+	DefaultAdminName     = "System Admin"
 
-    DefaultCandidateEmail    = "candidate@hireflow.com"
-    DefaultCandidatePassword = "Candidate@1234"
-    DefaultCandidateName     = "Test Candidate"
+	DefaultCandidateEmail    = "candidate@hireflow.com"
+	DefaultCandidatePassword = "Candidate@1234"
+	DefaultCandidateName     = "Test Candidate"
+
+	DefaultHiringManagerEmail    = "manager@hireflow.com"
+	DefaultHiringManagerPassword = "Manager@1234"
+	DefaultHiringManagerName     = "Test Hiring Manager"
 )
 
 // SeedAdmin creates a default admin user if none exists.
 // Safe to call on every startup - skips if admin already exists.
 func SeedAdmin(db *gorm.DB) {
-    var count int64
-    db.Model(&models.User{}).Where("role = ?", "admin").Count(&count)
+	var count int64
+	db.Model(&models.User{}).Where("role = ?", "admin").Count(&count)
 
-    // Admin already exists - skip seeding
-    if count > 0 {
-        log.Println("Admin user already exists - skipping seed")
-        return
-    }
+	if count > 0 {
+		log.Println("Admin user already exists - skipping seed")
+		return
+	}
 
-    // Create default admin user
-    admin := models.User{
-        Name:     DefaultAdminName,
-        Email:    DefaultAdminEmail,
-        Role:     "admin",
-        IsActive: true,
-    }
+	admin := models.User{
+		Name:     DefaultAdminName,
+		Email:    DefaultAdminEmail,
+		Role:     "admin",
+		IsActive: true,
+	}
 
-    // Hash default password
-    if err := admin.HashPassword(DefaultAdminPassword); err != nil {
-        log.Printf("Failed to hash admin password: %v", err)
-        return
-    }
+	if err := admin.HashPassword(DefaultAdminPassword); err != nil {
+		log.Printf("Failed to hash admin password: %v", err)
+		return
+	}
 
-    // Save admin to database
-    if err := db.Create(&admin).Error; err != nil {
-        log.Printf("Failed to create admin user: %v", err)
-        return
-    }
+	if err := db.Create(&admin).Error; err != nil {
+		log.Printf("Failed to create admin user: %v", err)
+		return
+	}
 
-    log.Println("✅ Default admin user created successfully")
-    log.Printf("   Email:    %s", DefaultAdminEmail)
-    log.Printf("   Password: %s", DefaultAdminPassword)
-    log.Println("   ⚠️  Change these credentials in production!")
+	log.Println("✅ Default admin user created successfully")
+	log.Printf("   Email:    %s", DefaultAdminEmail)
+	log.Printf("   Password: %s", DefaultAdminPassword)
+	log.Println("   ⚠️  Change these credentials in production!")
 }
 
 // SeedCandidate creates a default candidate user for E2E testing.
 // Safe to call on every startup - skips if candidate already exists.
 func SeedCandidate(db *gorm.DB) {
-    var count int64
-    db.Model(&models.User{}).Where("email = ?", DefaultCandidateEmail).Count(&count)
+	var count int64
+	db.Model(&models.User{}).Where("email = ?", DefaultCandidateEmail).Count(&count)
 
-    // Candidate already exists - skip seeding
-    if count > 0 {
-        log.Println("Test candidate user already exists - skipping seed")
-        return
-    }
+	if count > 0 {
+		log.Println("Test candidate user already exists - skipping seed")
+		return
+	}
 
-    // Create default candidate user
-    candidate := models.User{
-        Name:     DefaultCandidateName,
-        Email:    DefaultCandidateEmail,
-        Role:     "candidate",
-        IsActive: true,
-    }
+	candidate := models.User{
+		Name:     DefaultCandidateName,
+		Email:    DefaultCandidateEmail,
+		Role:     "candidate",
+		IsActive: true,
+	}
 
-    // Hash default password
-    if err := candidate.HashPassword(DefaultCandidatePassword); err != nil {
-        log.Printf("Failed to hash candidate password: %v", err)
-        return
-    }
+	if err := candidate.HashPassword(DefaultCandidatePassword); err != nil {
+		log.Printf("Failed to hash candidate password: %v", err)
+		return
+	}
 
-    // Save candidate to database
-    if err := db.Create(&candidate).Error; err != nil {
-        log.Printf("Failed to create candidate user: %v", err)
-        return
-    }
+	if err := db.Create(&candidate).Error; err != nil {
+		log.Printf("Failed to create candidate user: %v", err)
+		return
+	}
 
-    log.Println("✅ Default candidate user created successfully")
-    log.Printf("   Email:    %s", DefaultCandidateEmail)
-    log.Printf("   Password: %s", DefaultCandidatePassword)
-    log.Println("   ⚠️  For testing only - not for production use!")
+	log.Println("✅ Default candidate user created successfully")
+	log.Printf("   Email:    %s", DefaultCandidateEmail)
+	log.Printf("   Password: %s", DefaultCandidatePassword)
+	log.Println("   ⚠️  For testing only - not for production use!")
+}
+
+// SeedHiringManager creates a default hiring manager user for E2E testing.
+// Safe to call on every startup - skips if hiring manager already exists.
+func SeedHiringManager(db *gorm.DB) {
+	var count int64
+	db.Model(&models.User{}).Where("email = ?", DefaultHiringManagerEmail).Count(&count)
+
+	if count > 0 {
+		log.Println("Test hiring manager user already exists - skipping seed")
+		return
+	}
+
+	manager := models.User{
+		Name:     DefaultHiringManagerName,
+		Email:    DefaultHiringManagerEmail,
+		Role:     "hiring_manager",
+		IsActive: true,
+	}
+
+	if err := manager.HashPassword(DefaultHiringManagerPassword); err != nil {
+		log.Printf("Failed to hash hiring manager password: %v", err)
+		return
+	}
+
+	if err := db.Create(&manager).Error; err != nil {
+		log.Printf("Failed to create hiring manager user: %v", err)
+		return
+	}
+
+	log.Println("✅ Default hiring manager user created successfully")
+	log.Printf("   Email:    %s", DefaultHiringManagerEmail)
+	log.Printf("   Password: %s", DefaultHiringManagerPassword)
+	log.Println("   ⚠️  For testing only - not for production use!")
 }

--- a/docs/Sprint2.md
+++ b/docs/Sprint2.md
@@ -121,38 +121,37 @@ Obtain a token via `POST /auth/login`.
 
 **Description:** Register a new user account  
 **Auth Required:** No  
-**Role Required:** None
+**Role Required:** None  
+> ⚠️ **Updated in Sprint 3:** Self-registration always creates `candidate` role.
+> To create admin/hiring_manager/interviewer accounts, use `POST /users` (admin only).
 
 **Request Body:**
-
 ```json
 {
   "name": "John Doe",
   "email": "john@example.com",
-  "password": "SecurePass123!",
-  "role": "hiring_manager"
+  "password": "SecurePass123!"
 }
 ```
 
 **Password Rules:**
-
 - Minimum 8 characters
 - At least one uppercase letter
 - At least one lowercase letter
 - At least one number
-- At least one special character (!@#$%^&\*)
+- At least one special character (!@#$%^&*)
 
-**Valid Roles:** `admin`, `hiring_manager`, `interviewer`, `candidate`
+**Note:** The `role` field is accepted but ignored. All self-registered users
+are assigned `candidate` role automatically. This prevents privilege escalation.
 
 **Success Response (201 Created):**
-
 ```json
 {
   "user": {
     "id": 1,
     "name": "John Doe",
     "email": "john@example.com",
-    "role": "hiring_manager",
+    "role": "candidate",
     "is_active": true
   },
   "access_token": "eyJhbGciOiJIUzI1NiIs...",
@@ -162,13 +161,12 @@ Obtain a token via `POST /auth/login`.
 
 **Error Responses:**
 
-| Status | Reason                   |
-| ------ | ------------------------ |
-| 400    | Missing required fields  |
-| 400    | Invalid email format     |
-| 400    | Weak password            |
-| 400    | Invalid role             |
-| 409    | Email already registered |
+| Status | Reason |
+|--------|--------|
+| 400 | Missing required fields |
+| 400 | Invalid email format |
+| 400 | Weak password |
+| 409 | Email already registered |
 
 ---
 

--- a/docs/Sprint3.md
+++ b/docs/Sprint3.md
@@ -1,0 +1,209 @@
+# HireFlow Sprint 3 - Backend API Documentation
+
+**Owner:** BE1 (Identity & Auth)  
+**Backend:** Go + Gorilla Mux + GORM + SQLite  
+**Base URL:** `http://localhost:8080`  
+**Authentication:** Bearer JWT Token
+
+---
+
+## Sprint 3 Summary
+
+### Completed in Sprint 3 (BE1):
+- Fixed self-registration to always create candidate role (security fix)
+- Implemented GET /dashboard/stats endpoint for hiring dashboard
+- Added role-based protection to dashboard endpoint
+- Fixed candidate route references to match BE2's updated method names
+- Extended seeder with test candidate and hiring manager users
+- Implemented 7 unit tests for dashboard stats handler
+- Updated Sprint2.md to reflect self-registration change
+
+### Endpoints Completed or Improved:
+- `POST /auth/register` - Now enforces candidate role (security fix)
+- `GET /dashboard/stats` - New endpoint for hiring dashboard stats
+
+### Backend Unit Tests Added:
+- Dashboard stats handler: 7 tests
+- Self-registration role enforcement: 3 new tests added to auth handler
+- **Sprint 3 total: 10 new tests**
+- **Cumulative total: 48 tests**
+
+### Known Limitations:
+- Google OAuth implementation handled separately by team lead
+- Resume upload handled by BE2
+- Dashboard stats uses SQLite GROUP BY (adequate for demo scale)
+
+---
+
+## Default Test Credentials
+
+For development and E2E testing:
+
+| Role | Email | Password |
+|------|-------|----------|
+| Admin | `admin@hireflow.com` | `Admin@1234` |
+| Candidate | `candidate@hireflow.com` | `Candidate@1234` |
+| Hiring Manager | `manager@hireflow.com` | `Manager@1234` |
+
+> ⚠️ Change all credentials in production!
+
+---
+
+## New Endpoints
+
+---
+
+### 1. GET /dashboard/stats
+
+**Description:** Returns aggregated hiring statistics for the dashboard  
+**Auth Required:** Yes  
+**Role Required:** `admin`, `hiring_manager`, `interviewer` (candidates excluded)
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
+**Success Response (200 OK):**
+```json
+{
+  "totalJobs": 6,
+  "openJobs": 5,
+  "closedJobs": 1,
+  "totalCandidates": 22,
+  "totalUsers": 10,
+  "departmentSummary": [
+    { "department": "Engineering", "openCount": 3, "closedCount": 0 },
+    { "department": "Design", "openCount": 1, "closedCount": 0 },
+    { "department": "Marketing", "openCount": 1, "closedCount": 1 }
+  ]
+}
+```
+
+**Field Descriptions:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalJobs` | int | Total number of job postings |
+| `openJobs` | int | Jobs with status = "Open" |
+| `closedJobs` | int | Jobs with status = "Closed" |
+| `totalCandidates` | int | Total applications excluding WITHDRAWN |
+| `totalUsers` | int | Total system users (all roles) |
+| `departmentSummary` | array | Job counts grouped by department |
+
+**Error Responses:**
+
+| Status | Reason |
+|--------|--------|
+| 401 | Missing or invalid token |
+| 403 | Candidate role not permitted |
+| 500 | Database error |
+
+---
+
+## Modified Endpoints
+
+---
+
+### POST /auth/register (Security Fix)
+
+**What changed:** Self-registration now **always** creates a user with `candidate` role regardless of what role is passed in the request body.
+
+**Before (Sprint 2):**
+```json
+{
+  "name": "Sneaky User",
+  "email": "sneaky@example.com",
+  "password": "SecurePass123!",
+  "role": "admin"  // Was accepted - security vulnerability!
+}
+```
+
+**After (Sprint 3):**
+```json
+{
+  "name": "John Doe",
+  "email": "john@example.com",
+  "password": "SecurePass123!",
+  "role": "admin"  // Ignored - always becomes "candidate"
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "user": {
+    "id": 1,
+    "name": "John Doe",
+    "email": "john@example.com",
+    "role": "candidate",  // Always candidate regardless of input
+    "is_active": true
+  },
+  "access_token": "eyJhbGciOiJIUzI1NiIs...",
+  "expires_in": 900
+}
+```
+
+**Why:** Prevents privilege escalation where users could self-assign admin or hiring_manager roles. Admins must use `POST /users` to create non-candidate users.
+
+---
+
+## Running Backend Tests
+
+```bash
+# Run all tests
+cd backend
+go test ./... -v
+
+# Run specific Sprint 3 tests
+go test ./handlers/ -run TestGetDashboardStats -v
+go test ./handlers/ -run TestRegister -v
+
+# Run all handler tests
+go test ./handlers/ -v
+```
+
+---
+
+## Developer Setup
+
+### Prerequisites
+- Go 1.21+
+- No GCC required (Pure Go SQLite driver)
+
+### Running the Backend
+```bash
+cd backend
+go run main.go
+```
+
+### Auto-Created Seed Users
+On first startup, the backend automatically creates these test users:
+
+```
+✅ Admin:           admin@hireflow.com     / Admin@1234
+✅ Candidate:       candidate@hireflow.com / Candidate@1234
+✅ Hiring Manager:  manager@hireflow.com   / Manager@1234
+```
+
+---
+
+## Complete Test Coverage (Cumulative)
+
+| Handler | Sprint 2 Tests | Sprint 3 Tests | Total |
+|---------|---------------|----------------|-------|
+| Auth Handler | 15 | 3 (role enforcement) | 18 |
+| User Handler | 11 | 0 | 11 |
+| Job Handler | 12 | 0 | 12 |
+| Dashboard Handler | 0 | 7 | 7 |
+| **Total** | **38** | **10** | **48** |
+
+---
+
+## Security Improvements in Sprint 3
+
+| Issue | Status | Fix |
+|-------|--------|-----|
+| Self-registration privilege escalation | ✅ Fixed | Force candidate role on /auth/register |
+| Dashboard accessible to candidates | ✅ Fixed | RequireRole middleware excludes candidates |
+| Job routes unprotected | ✅ Already fixed in Sprint 2 | RequireAuth + RequireRole |


### PR DESCRIPTION
## BE1 Sprint 3 Summary

### Security Fix:
- POST /auth/register now always creates candidate role
- Prevents privilege escalation (users cannot self-assign admin/hiring_manager)
- 3 new security tests added to verify enforcement

### New Features:
- GET /dashboard/stats endpoint (admin/hiring_manager/interviewer only)
- Returns: totalJobs, openJobs, closedJobs, totalCandidates, totalUsers, departmentSummary
- Dashboard already wired up by Vardhan (FE2) - endpoint goes live immediately

### Seed Users (auto-created on startup):
- admin@hireflow.com / Admin@1234
- candidate@hireflow.com / Candidate@1234
- manager@hireflow.com / Manager@1234

### Bug Fix:
- Fixed candidate route references to match BE2's updated method names
- Fixed dashboard_handler.go code quality (tagged switch)

### Tests (10 new, 48 cumulative):
- 7 dashboard stats handler tests
- 3 self-registration role enforcement tests

### Documentation:
- Added docs/Sprint3.md (209 lines)
- Updated docs/Sprint2.md with security fix notice

### Commits (9 total):
1. fix: Enforce candidate role on self-registration
2. test: Add unit tests for self-registration role enforcement
3. feat: Add DashboardStats response struct and handler
4. feat: Add /dashboard/stats route with role-based protection
5. fix: Update candidate routes + dashboard code quality
6. test: Add unit tests for dashboard stats handler (7 tests)
7. feat: Add candidate seed user for E2E testing
8. feat: Add hiring manager seed user for E2E testing
9. docs: Add Sprint3.md with new endpoint documentation
10. docs: Update Sprint2.md to reflect self-registration change

### Pre-merge Verification:
- ✅ All 48 tests passing
- ✅ Clean working tree
- ✅ No conflicts with remote main (verified with dry run merge)
- ✅ Build successful